### PR TITLE
University of Hannover (LUH) apc data

### DIFF
--- a/data/unihannover/unihannover.csv
+++ b/data/unihannover/unihannover.csv
@@ -15,3 +15,18 @@ Leibniz Universität Hannover,2013,1157.95,10.3390/v5102512,MDPI,Viruses,1999-49
 Leibniz Universität Hannover,2013,1616.68,10.1364/OE.21.029656,Optical Society of America,Optics Express,1094-4087,NA,NA,NA
 Leibniz Universität Hannover,2013,999.60,10.5194/amtd-6-11145-2013,Copernicus,Atmospheric Measurement Techniques Discussions,1867-8610,NA,NA,NA
 Leibniz Universität Hannover,2013,1017.45,10.1186/2191-1991-3-29,Springer,Health Economics Review,2191-1991,NA,NA,NA
+Leibniz Universität Hannover,2014,828.24,10.5194/amtd-7-69-2014,Copernicus,Atmospheric Measurement Techniques Discussions,1867-8610,NA,NA,NA
+Leibniz Universität Hannover,2014,779.97,10.3390/su6010236,MDPI,Sustainability,2071-1050,NA,NA,NA
+Leibniz Universität Hannover,2014,779.89,10.3390/su6020836,MDPI,Sustainability,2071-1050,NA,NA,NA
+Leibniz Universität Hannover,2014,1874.25,10.1186/1471-2148-14-92,BioMed Central,BMC Evolutionary Biology,1471-2148,NA,NA,NA
+Leibniz Universität Hannover,2014,1638.51,10.1364/OE.22.003866,Optical Society of America,Optics Express,1094-4087,NA,NA,NA
+Leibniz Universität Hannover,2014,1366.32,10.1364/OE.22.005234,Optical Society of America,Optics Express,1094-4087,NA,NA,NA
+Leibniz Universität Hannover,2014,1178.10,10.1088/1367-2630/16/4/043007,IOP Publishing,New Journal of Physics,1367-2630,NA,NA,NA
+Leibniz Universität Hannover,2014,1993.25,10.1186/1472-6963-14-166,BioMed Central,BMC Health Services Research,1472-6963,NA,NA,NA
+Leibniz Universität Hannover,2014,1142.40,10.3389/fpls.2014.00163,Frontiers,Frontiers in Plant Science,1664-462X,NA,NA,NA
+Leibniz Universität Hannover,2014,1456.56,10.1088/1367-2630/16/5/053043,IOP Publishing,New Journal of Physics,1367-2630,NA,NA,NA
+Leibniz Universität Hannover,2014,1568.00,10.1127/0941-2948/2014/0577,Schweizerbart,Meteorologische Zeitschrift,0941-2948,NA,NA,NA
+Leibniz Universität Hannover,2014,1191.38,10.1364/BOE.5.002054,Optical Society of America,Biomedical Optics Express,2156-7085,NA,NA,NA
+Leibniz Universität Hannover,2014,802.93,10.5194/nhessd-2-3683-2014,Copernicus,Natural Hazards and Earth System Sciences Discussions,2195-9269,NA,NA,NA
+Leibniz Universität Hannover,2014,1904.00,10.3389/fpls.2014.00341,Frontiers,Frontiers in Plant Science,1664-462X,NA,NA,NA
+Leibniz Universität Hannover,2014,1758.62,10.3390/s140712715,MDPI,Sensors,1424-8220,NA,NA,NA


### PR DESCRIPTION
- added APC costs that the open access fund of _Leibniz Universität Hannover_ has paid for
- data from 2013 and 2014 YTD
- fund supported by _Deutsche Forschungsgemeinschaft_ (DFG)
- information available under http://tib.uni-hannover.de/oafonds
