### PR TITLE
Add PAR fees from Wiley-DEAL 2019

### DIFF
--- a/data/unimannheim/README.md
+++ b/data/unimannheim/README.md
@@ -1,7 +1,9 @@
-# APC data from the University of Mannheim
+# APC and PAR data from the University of Mannheim
 
 The University of Mannheim has an Open Access Publishing Fonds which is managed by the Mannheim University Library. The open access publishing fund is financed by the Ministry of Science, Research and the Arts Baden-Württemberg, the Mannheim Centre for European Social Research (MZES) and the university library.
 
 More information:
 - 🇺🇸 https://www.bib.uni-mannheim.de/en/open-access-publishing-fund/
 - 🇩🇪 https://www.bib.uni-mannheim.de/open-access-publikationsfonds/
+
+Additionally, the calculated PAR fees from the Wiley-DEAL from 2019 are also part of these data.

--- a/data/unimannheim/par-wiley-unimannheim-2019.csv
+++ b/data/unimannheim/par-wiley-unimannheim-2019.csv
@@ -1,0 +1,11 @@
+institution,period,euro,doi,is_hybrid,opt_out,Article URL
+Universität Mannheim,2019,17659,10.1002/mma.6121,TRUE,Opt-In,http://onlinelibrary.wiley.com/doi/10.1002/mma.6121
+Universität Mannheim,2019,17659,10.1111/ajps.12501,TRUE,Opt-In,http://onlinelibrary.wiley.com/doi/10.1111/ajps.12501
+Universität Mannheim,2019,17659,10.1111/1475-6765.12361,TRUE,Opt-In,http://onlinelibrary.wiley.com/doi/10.1111/1475-6765.12361
+Universität Mannheim,2019,17659,10.1111/beer.12252,TRUE,Opt-In,http://onlinelibrary.wiley.com/doi/10.1111/beer.12252
+Universität Mannheim,2019,17659,10.1111/poms.13116,TRUE,Opt-In,http://onlinelibrary.wiley.com/doi/10.1111/poms.13116
+Universität Mannheim,2019,17659,10.1111/obr.12935,TRUE,Opt-In,http://onlinelibrary.wiley.com/doi/10.1111/obr.12935
+Universität Mannheim,2019,17659,10.1111/joes.12337,TRUE,Opt-In,http://onlinelibrary.wiley.com/doi/10.1111/joes.12337
+Universität Mannheim,2019,17659,10.1111/joop.12290,TRUE,Opt-In,http://onlinelibrary.wiley.com/doi/10.1111/joop.12290
+Universität Mannheim,2019,17659,10.1002/mma.6013,TRUE,Opt-In,https://onlinelibrary.wiley.com/doi/full/10.1002/mma.6013
+Universität Mannheim,2019,17659,10.1111/jpim.12512,TRUE,Opt-Out,https://onlinelibrary.wiley.com/doi/full/10.1111/jpim.12512


### PR DESCRIPTION
One wrong opt-out case from MPDI is neglected here. The calculation of the PAR fee is with the amount paid for the complete year, i.e. it needs to be halved centrally by openAPC.