### PR TITLE
Update 2022_openapc_tuberlin.csv

### DIFF
--- a/data/tuberlin/2022_openapc_tuberlin.csv
+++ b/data/tuberlin/2022_openapc_tuberlin.csv
@@ -206,3 +206,8 @@ TU Berlin,2022,2001.37,10.1038/s41598-022-20964-4,,Springer Nature,Scientific Re
 TU Berlin,2022,5579.37,10.1038/s41467-022-33165-4,,Springer Nature,Nature Communications,https://creativecommons.org/licenses/by/4.0/
 TU Berlin,2022,5579.37,10.1038/s41467-022-35426-8,,Nature Publishing Group,Nature Communications,https://creativecommons.org/licenses/by/4.0/
 TU Berlin,2022,5579.37,10.1038/s41467-022-34125-8,,Springer Nature,Nature Communications,https://creativecommons.org/licenses/by/4.0/
+TU Berlin,2022,1352.03,10.3390/batteries8020008,,MDPI,Batteries,https://creativecommons.org/licenses/by/4.0/
+TU Berlin,2022,1352.03,10.3390/batteries8020011,,MDPI,Batteries,https://creativecommons.org/licenses/by/4.0/
+TU Berlin,2022,1201.80,10.3390/aerospace9020078,,MDPI,Aerospace,https://creativecommons.org/licenses/by/4.0/
+TU Berlin,2022,1931.47,10.3390/biomedicines10020395,,MDPI,Biomedicines,https://creativecommons.org/licenses/by/4.0/
+TU Berlin,2022,1931.47,10.3390/ijms23031196,,MDPI,International Journal of Molecular Sciences,https://creativecommons.org/licenses/by/4.0/


### PR DESCRIPTION
5 Nachzügler für den OA-Publikationsfonds 2022 der TU Berlin